### PR TITLE
Remove oe_machinstall

### DIFF
--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -51,7 +51,6 @@ KERNEL_PACKAGE_NAME = "kernel"
 FILES:${KERNEL_PACKAGE_NAME}-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
 
 do_configure:prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig
 	if ${@bb.utils.contains("MACHINE_FEATURES", 'dvbproxy', 'true', 'false', d)}; then
 		sed -i "s/bmem=220M@512M/bmem=384M@512M/g" ${WORKDIR}/defconfig
 	fi

--- a/recipes-bsp/linux/linux-vuplus-3.14.28.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.14.28.inc
@@ -47,10 +47,6 @@ KERNEL_IMAGEDEST = "tmp"
 
 FILES:${KERNEL_PACKAGE_NAME}-image = "/${KERNEL_IMAGEDEST}/zImage"
 
-do_configure:prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig
-}
-
 kernel_do_install:append() {
         install -d ${D}/${KERNEL_IMAGEDEST}
         install -m 0755 ${KERNEL_OUTPUT} ${D}/${KERNEL_IMAGEDEST}

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -48,10 +48,6 @@ KERNEL_IMAGEDEST = "/tmp"
 
 FILES:${KERNEL_PACKAGE_NAME}-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
 
-do_configure:prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig
-}
-
 kernel_do_install:append() {
 	install -d ${D}/${KERNEL_IMAGEDEST}
 	install -m 0755 ${KERNEL_OUTPUT} ${D}${KERNEL_IMAGEDEST}

--- a/recipes-bsp/linux/linux-vuplus-4.1.20.inc
+++ b/recipes-bsp/linux/linux-vuplus-4.1.20.inc
@@ -63,10 +63,6 @@ KERNEL_IMAGEDEST = "tmp"
 
 FILES:${KERNEL_PACKAGE_NAME}-image = "/${KERNEL_IMAGEDEST}/zImage"
 
-do_configure:prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig
-}
-
 kernel_do_install:append() {
         install -d ${D}/${KERNEL_IMAGEDEST}
         install -m 0755 ${KERNEL_OUTPUT} ${D}/${KERNEL_IMAGEDEST}

--- a/recipes-bsp/linux/linux-vuplus-4.1.45.inc
+++ b/recipes-bsp/linux/linux-vuplus-4.1.45.inc
@@ -61,10 +61,6 @@ KERNEL_IMAGEDEST = "tmp"
 
 FILES:${KERNEL_PACKAGE_NAME}-image = "/${KERNEL_IMAGEDEST}/zImage"
 
-do_configure:prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig
-}
-
 kernel_do_install:append() {
         install -d ${D}/${KERNEL_IMAGEDEST}
         install -m 0755 ${KERNEL_OUTPUT} ${D}/${KERNEL_IMAGEDEST}


### PR DESCRIPTION
Removed from openembedded-core, no replacement.

 DEBUG: Executing shell function do_configure
| WARNING: exit code 127 from a shell command.
| /home/hains/openpli-oe-core/build/tmp/work/vuultimo4k-oe-linux-gnueabi/linux-vuultimo4k/3.14.28-r1.4.3 /temp/run.do_configure.52810: 149: oe_machinstall: not found