### PR TITLE
hmp-usb-dvb-t2-c: Refresh rename_dvb-usb-v2 patch

### DIFF
--- a/recipes-driver/hmp/hmp-usb-dvb-t2-c-v03arm/rename_dvb-usb-v2.patch
+++ b/recipes-driver/hmp/hmp-usb-dvb-t2-c-v03arm/rename_dvb-usb-v2.patch
@@ -7,5 +7,5 @@ diff -Naur media_build-bst-14.orig/linux/drivers/media/usb/dvb-usb-v2/Makefile m
 +dvb_usb_v2_media_tree-objs := dvb_usb_core.o dvb_usb_urb.o usb_urb.o
 +obj-$(CONFIG_DVB_USB_V2) += dvb_usb_v2_media_tree.o
  
- dvb-usb-af9015-objs := af9015.o
- obj-$(CONFIG_DVB_USB_AF9015) += dvb-usb-af9015.o
+ #dvb-usb-af9015-objs := af9015.o
+ #obj-$(CONFIG_DVB_USB_AF9015) += dvb-usb-af9015.o


### PR DESCRIPTION
Applying patch rename_dvb-usb-v2.patch
patching file linux/drivers/media/usb/dvb-usb-v2/Makefile Hunk #1 succeeded at 1 with fuzz 2.