### PR TITLE
vuxxo4k.inc: Remove hmp-usb-dvb-t2-c-arm

### DIFF
--- a/conf/machine/include/vuxxo4k.inc
+++ b/conf/machine/include/vuxxo4k.inc
@@ -24,7 +24,6 @@ EXTRA_IMAGEDEPENDS += "\
 	enigma2-plugin-extensions-addstreamurl \
 	vuplus-tuner-turbo \
 	vuplus-tuner-turbo2 \
-	hmp-usb-dvb-t2-c-arm \
 	${@bb.utils.contains("MACHINE_FEATURES", "bluetooth", "enigma2-plugin-systemplugins-bluetoothsetup", "", d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "bcmwifi", "vuplus-wifi-util-${MACHINE}", "", d)} \
 "

--- a/conf/machine/vuduo4k.conf
+++ b/conf/machine/vuduo4k.conf
@@ -33,7 +33,6 @@ IMAGE_INSTALL:append = "\
 
 PREFERRED_VERSION_mmc-utils = "0.2"
 PREFERRED_VERSION_linux-${MACHINE} = "4.1.45"
-PREFERRED_VERSION_hmp-usb-dvb-t2-c-arm = "V160430"
 
 FORCE_REBOOT_OPTION = "reboot"
 

--- a/conf/machine/vuduo4kse.conf
+++ b/conf/machine/vuduo4kse.conf
@@ -32,7 +32,6 @@ IMAGE_INSTALL:append = "\
 	"
 
 PREFERRED_VERSION_linux-${MACHINE} = "4.1.45"
-PREFERRED_VERSION_hmp-usb-dvb-t2-c-arm = "V160430"
 
 FORCE_REBOOT_OPTION = "reboot"
 


### PR DESCRIPTION
To fx build:

ERROR: hmp-usb-dvb-t2-c-arm-V160430-r1 do_packagedata: The recipe hmp-usb-dvb-t2-c-arm is trying to install files into a shared area when those files already exist. Those files and their manifest location are:
  /home/hains/openpli-oe-core/build/tmp/pkgdata/vuduo4k/runtime/kernel-module-dvb-usb-dvbsky-4.1.45-1.17
    (matched in manifest-vuduo4k-linux-vuduo4k.packagedata)
  /home/hains/openpli-oe-core/build/tmp/pkgdata/vuduo4k/extended/kernel-module-dvb-usb-dvbsky-4.1.45-1.17.json.zstd
    (matched in manifest-vuduo4k-linux-vuduo4k.packagedata)
Please verify which recipe should provide the above files.