### PR TITLE
vuplus-webkithbbtv-dumpait: Set branch

### DIFF
--- a/recipes-bsp/webkit-hbbtv/vuplus-webkithbbtv-dumpait.bb
+++ b/recipes-bsp/webkit-hbbtv/vuplus-webkithbbtv-dumpait.bb
@@ -14,7 +14,7 @@ PR = "r0"
 
 DEPENDS = "libdvbsi++"
 
-SRC_URI = "git://github.com/vuplus-com/dumpait.git;protocol=https"
+SRC_URI = "git://github.com/vuplus-com/dumpait.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 DESTDIR = "enigma2/python/Plugins/Extensions/WebkitHbbTV"


### PR DESCRIPTION
Silence warning:

WARNING: URL: git://github.com/vuplus-com/dumpait.git;protocol=https does not set any branch parameter. The future default branch used by tools and repositories is uncertain and we will therefore soon require this is set in all git urls.